### PR TITLE
TRAN-179 redesigned decline friend request

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -107,7 +107,6 @@ enum FriendStatus {
   PENDING
   BLOCKED
   ACCEPTED
-  DECLINED
 }
 
 // =====================================================================

--- a/backend/src/friends/friends.controller.ts
+++ b/backend/src/friends/friends.controller.ts
@@ -76,7 +76,7 @@ export class FriendsController {
   }
 
   /* When a user declines a request from another user*/
-  @Put('declineRequest')
+  @Delete('declineRequest')
   declineRequest(@Body() dto: FriendsDto) {
     try {
       return this.friendsService.declineRequest(dto.userLogin, dto.friendLogin);

--- a/backend/src/friends/friends.service.ts
+++ b/backend/src/friends/friends.service.ts
@@ -162,7 +162,7 @@ export class FriendsService {
       return 'Friend Request Cancelled';
     } else {
       throw new BadRequestException(
-        'Friend Request already Accepted/Declined/Blocked',
+        'Friend Request already Accepted/Blocked',
       );
     }
   }
@@ -195,7 +195,7 @@ export class FriendsService {
       return 'Friend Request Accepted';
     } else {
       throw new BadRequestException(
-        'Friend Request already Accepted/Declined/Blocked',
+        'Friend Request already Accepted/Blocked',
       );
     }
   }
@@ -216,19 +216,16 @@ export class FriendsService {
     }
 
     if (relation.friendStatus === 'PENDING') {
-      await this.prisma.friendRelation.updateMany({
+      await this.prisma.friendRelation.deleteMany({
         where: {
           userId: reqFromData.id,
           friendId: userData.id,
-        },
-        data: {
-          friendStatus: 'DECLINED',
-        },
+        }
       });
       return 'Friend Request Declined';
     } else {
       throw new BadRequestException(
-        'Friend Request already Accepted/Declined/Blocked',
+        'Friend Request already Accepted/Blocked',
       );
     }
   }
@@ -306,7 +303,7 @@ export class FriendsService {
       return 'Friend has been Blocked';
     } else {
       /* User will not be able to block the other user, if friendStatus is 
-      PENDING/DECLINED/BLOCKED(by other user) */
+      PENDING/BLOCKED(by other user) */
       throw new BadRequestException('This user is not a friend');
     }
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,7 +29,8 @@
         "react-input-emoji": "^5.3.1",
         "react-toastify": "^9.1.3",
         "tailwindcss": "3.3.3",
-        "typescript": "5.1.6"
+        "typescript": "5.1.6",
+        "zustand": "^4.4.4"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -4586,6 +4587,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/util": {
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -4706,6 +4715,33 @@
       "integrity": "sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.4.4.tgz",
+      "integrity": "sha512-5UTUIAiHMNf5+mFp7/AnzJXS7+XxktULFN0+D1sCiZWyX7ZG+AQpqs2qpYrynRij4QvoDdCD+U+bmg/cG3Ucxw==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/frontend/src/components/Table/TableCell.tsx
+++ b/frontend/src/components/Table/TableCell.tsx
@@ -51,7 +51,7 @@ const TableCell: React.FC<TableCellProps> = ({ dataItem, login }) => {
         endpoint = API_ENDPOINTS.acceptFriendRequest;
         break;
       case "DECLINE":
-        action = updateFriendRelation;
+        action = deleteFriendRelation;
         endpoint = API_ENDPOINTS.declineFriendRequest;
         break;
       case "ADDFRIEND":

--- a/frontend/src/data/Table/profileTableHeadings.tsx
+++ b/frontend/src/data/Table/profileTableHeadings.tsx
@@ -5,7 +5,7 @@ export const friendsProfileHeadings = [
   'Wins',
   'Losses',
   'Block',
-  'Delete',
+  'Unfriend',
 ];
 
 export const searchProfileHeadings = [
@@ -24,7 +24,7 @@ export const blockedFriendsHeadings = [
   'Wins',
   'Losses',
   'UnBlock',
-  'Delete',
+  'Unfriend',
 ];
 
 export const friendsRequestHeadings = [


### PR DESCRIPTION
In reference to issue #86 

1. Redesigned 'DECLINE FRIEND REQUEST' to delete the entry from the friend-relations table. This way user can send a friend request to this friend in the future.
2. Removed the value 'DECLINED' from the enum FriendStatus {} in Prisma model.
3. Changed header from 'delete' to 'unfriend' in 2 tabs on the profile page to make the actions more clear.